### PR TITLE
Fix TypeScript errors in WorkflowIntegration and SupplierDashboard

### DIFF
--- a/src/components/WorkflowIntegration.tsx
+++ b/src/components/WorkflowIntegration.tsx
@@ -145,7 +145,9 @@ const WorkflowIntegration: React.FC<WorkflowIntegrationProps> = ({ initialStep =
   useEffect(() => {
     if (workflowState) {
       const completedSteps = workflowSteps.filter(step => step.completed).length;
-      setCurrentStep(completedSteps);
+      // Find the first incomplete step or default to 'discover'
+      const firstIncompleteStep = workflowSteps.find(step => !step.completed);
+      setCurrentStep(firstIncompleteStep?.id || 'discover');
     }
   }, [workflowState]);
 
@@ -261,7 +263,7 @@ const WorkflowIntegration: React.FC<WorkflowIntegrationProps> = ({ initialStep =
                     className="border border-gray-300 rounded-md px-3 py-2 text-sm"
                   >
                     <option value="">All Categories</option>
-                    {[...new Set((allInventory||[]).map(i => i.category))].map(cat => (
+                    {[...new Set((allInventory||[]).map(i => i.category))].map((cat: string) => (
                       <option key={cat} value={cat}>{cat}</option>
                     ))}
                   </select>

--- a/src/pages/SupplierDashboard.tsx
+++ b/src/pages/SupplierDashboard.tsx
@@ -38,6 +38,10 @@ interface Order {
   items: any[];
   vendorId: string;
   createdAt: number;
+  vendor?: {
+    businessName: string;
+    email?: string;
+  };
 }
 
 interface SupplierProfile {


### PR DESCRIPTION
## Purpose
Fix TypeScript compilation errors that were causing Netlify build failures. The build was failing at the "npm run build" step due to type mismatches in WorkflowIntegration.tsx and SupplierDashboard.tsx files.

## Code changes
- **WorkflowIntegration.tsx**: 
  - Fixed `setCurrentStep` to accept string ID instead of number by finding the first incomplete step
  - Added explicit type annotation `(cat: string)` for category mapping to resolve type inference issues
- **SupplierDashboard.tsx**: 
  - Extended `Order` interface to include optional `vendor` property with `businessName` and `email` fields

These changes resolve the TypeScript compilation errors and should allow the Netlify build to succeed.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/25d494508b774fdf9e2b4b01b4a59286/curry-oasis)

👀 [Preview Link](https://25d494508b774fdf9e2b4b01b4a59286-curry-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>25d494508b774fdf9e2b4b01b4a59286</projectId>-->
<!--<branchName>curry-oasis</branchName>-->